### PR TITLE
Chore/ci/examples

### DIFF
--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -3,21 +3,22 @@ on:
   push:
     branches:
     - master
+    - "**"
 jobs:
   deploy:
     name: gh-pages
     runs-on: ubuntu-latest
     container:
-      image: nimlang/nim:latest
+      image: nimlang/nim:latest-alpine
     steps:
     - uses: actions/checkout@v1
     - name: Build docs
       run: |
-        apt-get update && apt-get install -y rsync curl
+        apk add --no-cache rsync curl
         nimble i
         nimble docs
     - uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.DNICE_BOT_TOKEN }}
-        BRANCH: gh-pages
+        BRANCH: gh-pages-test
         FOLDER: public

--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
     - master
-    - "**"
 jobs:
   deploy:
     name: gh-pages
@@ -20,5 +19,5 @@ jobs:
     - uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.DNICE_BOT_TOKEN }}
-        BRANCH: gh-pages-test
+        BRANCH: gh-pages
         FOLDER: public

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,17 @@
+name: examples
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: nimlang/nim:latest-alpine
+    steps:
+    - uses: actions/checkout@v1
+    - name: assert runnable examples
+      run: |
+        nimble i
+        nimble docs

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Nim binding library to the Argon2 [C implementation](https://github.com/P-H-C/ph
 <!-- vim-markdown-toc GFM -->
 
 * [Dependencies](#dependencies)
-  * [Static Linking](#static-linking)
+  * [Static Linking (default)](#static-linking-default)
   * [Dynamic Linking](#dynamic-linking)
     * [Supported Distros](#supported-distros)
 * [Docs](#docs)
@@ -16,14 +16,14 @@ Nim binding library to the Argon2 [C implementation](https://github.com/P-H-C/ph
 
 ## Dependencies
 
-### Static Linking
+### Static Linking (default)
 
-* None (this is the default and should yield best cross-platform results)
+* requires `--threads:on` flag when compiling
 
 ### Dynamic Linking
 
 * libargon2
-* pass `-d:dynlink` flag when compiling
+* pass `-d:dynlink` flag when compiling to trigger dynamic argon2 use
 
 #### Supported Distros
 
@@ -42,6 +42,6 @@ You will need at least 1 GiB of free memory to run the tests.
 ### Multithreading
 
 The argon2 execution will be multithreaded in all instances, except if
-using `--dynlibOverride:libargon2 -d:dynlink`. It doesn't make much sense
-to pass these parameters though, with the static linking being built-in as
-the default.
+using `--dynlibOverride:libargon2 -d:dynlink`, even if you pass `--threads:on`.
+However, it doesn't make much sense to pass these parameters though, with the
+static linking being built-in as the default.


### PR DESCRIPTION
adds an examples actions, which helps make sure the deployer doesn't fail on the docs build due to some changes, as it did due to the static change, which ended up requiring `--threads:on` flag on ubuntu.

Track this issue here: https://github.com/nim-lang/Nim/issues/13129

In meantime, a workaround was to use the alpine container, which doesn't require explicit threads flag.