### PR TITLE
Chore/ci/builder

### DIFF
--- a/.github/workflows/builder-linux.yml
+++ b/.github/workflows/builder-linux.yml
@@ -1,0 +1,21 @@
+name: builder-linux
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - chore/ci/builder
+  pull_request:
+    branches:
+      - master
+      - develop
+jobs:
+  build-static:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: |
+        apt-get update && apt-get install -y curl gcc openssl
+        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+        export PATH=~/.nimble/bin:$PATH
+        nim c -r --threads:on src/argon2_bind.nim

--- a/.github/workflows/builder-linux.yml
+++ b/.github/workflows/builder-linux.yml
@@ -14,8 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: |
-        apt-get update && apt-get install -y curl gcc openssl
+    - name: get nim
+      run: |
         curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+    - name: build
+      run: |
         export PATH=~/.nimble/bin:$PATH
         nim c -r --threads:on src/argon2_bind.nim
+  build-dynamic:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: get nim
+      run: |
+        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+    - name: get libargon2
+      run: sudo apt update && sudo apt install libargon2-dev
+    - name: build
+      run: |
+        export PATH=~/.nimble/bin:$PATH
+        nim c -r -d:dynlink src/argon2_bind.nim

--- a/.github/workflows/builder-linux.yml
+++ b/.github/workflows/builder-linux.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
     - name: get libargon2
-      run: sudo apt update && sudo apt install libargon2-dev
+      run: sudo apt-get update && sudo apt-get install -y libargon2-0
     - name: build
       run: |
         export PATH=~/.nimble/bin:$PATH

--- a/.github/workflows/builder-macos.yml
+++ b/.github/workflows/builder-macos.yml
@@ -1,0 +1,34 @@
+name: builder-macos
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - chore/ci/builder
+  pull_request:
+    branches:
+      - master
+      - develop
+jobs:
+  build-static:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: get nim
+      run: |
+        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+    - name: build
+      run: |
+        export PATH=~/.nimble/bin:$PATH
+        nim c --threads:on src/argon2_bind.nim
+  build-dynamic:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: get nim
+      run: |
+        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+    - name: build
+      run: |
+        export PATH=~/.nimble/bin:$PATH
+        nim c -d:dynlink src/argon2_bind.nim

--- a/.github/workflows/builder-macos.yml
+++ b/.github/workflows/builder-macos.yml
@@ -16,10 +16,9 @@ jobs:
     - uses: actions/checkout@v1
     - name: get nim
       run: |
-        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+        brew install nim
     - name: build
       run: |
-        export PATH=~/.nimble/bin:$PATH
         nim c --threads:on src/argon2_bind.nim
   build-dynamic:
     runs-on: macos-latest
@@ -27,8 +26,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: get nim
       run: |
-        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+        brew install nim
     - name: build
       run: |
-        export PATH=~/.nimble/bin:$PATH
         nim c -d:dynlink src/argon2_bind.nim

--- a/.github/workflows/builder-win.yml
+++ b/.github/workflows/builder-win.yml
@@ -22,7 +22,7 @@ jobs:
     - name: build
       run: |
         export PATH=~/.nimble/bin:$PATH
-        nim c -r -d:mingw --threads:on src/argon2_bind.nim
+        nim c -d:mingw --threads:on src/argon2_bind.nim
   build-dynamic:
     runs-on: ubuntu-latest
     steps:
@@ -37,4 +37,4 @@ jobs:
     - name: build
       run: |
         export PATH=~/.nimble/bin:$PATH
-        nim c -r -d:mingw -d:dynlink src/argon2_bind.nim
+        nim c -d:mingw -d:dynlink src/argon2_bind.nim

--- a/.github/workflows/builder-win.yml
+++ b/.github/workflows/builder-win.yml
@@ -1,0 +1,40 @@
+name: builder-win
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - chore/ci/builder
+  pull_request:
+    branches:
+      - master
+      - develop
+jobs:
+  build-static:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: get nim
+      run: |
+        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+    - name: get mingw-w64
+      run: sudo apt-get update && sudo apt-get install -y mingw-w64
+    - name: build
+      run: |
+        export PATH=~/.nimble/bin:$PATH
+        nim c -r -d:mingw --threads:on src/argon2_bind.nim
+  build-dynamic:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: get nim
+      run: |
+        curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
+    - name: get mingw-w64
+      run: sudo apt-get update && sudo apt-get install -y mingw-w64
+    - name: get libargon2
+      run: sudo apt-get update && sudo apt-get install -y libargon2-0
+    - name: build
+      run: |
+        export PATH=~/.nimble/bin:$PATH
+        nim c -r -d:mingw -d:dynlink src/argon2_bind.nim

--- a/src/argon2_bind.nim
+++ b/src/argon2_bind.nim
@@ -58,6 +58,12 @@ when defined(dynLink):
   const libargon2 = DynlibFormat % "argon2" & "(|.1)"
   {.pragma: cffi, dynLib: libargon2, importc.}
 else:
+  when defined mingw:
+    # mingw cross-compile workaround
+    import strutils
+    proc `/`(h, t: string): string =
+      h.joinPath(t).replace("\\", $AltSep)
+
   const argon2BaseDir = currentSourcePath.parentDir /
     "argon2_bind" /
     "argon2"


### PR DESCRIPTION
Add various builders the library intends to support.

Implementaiton change in https://github.com/D-Nice/argon2_bind/commit/842289a9dfcf9ee657f6fc2f5fc855f54c11c6e6 which contains a patch for when using `mingw` flag for win cross-compilation, and the `DirSep` being set to `\`. Should open an issue to either make AltSep default use one or re-order `DirSep` conditionals to account for `mingw`?